### PR TITLE
fix shielpiercing check

### DIFF
--- a/gamedata/lua/lua/shield.lua
+++ b/gamedata/lua/lua/shield.lua
@@ -342,11 +342,11 @@ Shield = Class(moho.shield_methods,Entity) {
 
     -- Return true to process this collision, false to ignore it.
     OnCollisionCheck = function(self,other)
-	
-		if categories.SHIELDPIERCING then
+	        if categories.SHIELDPIERCING then
+		    if EntityCategoryContains( categories.SHIELDPIERCING, other ) then
 			return false
-		end
-
+		    end
+                end
 		-- for rail guns from 4DC credit Resin_Smoker
 		if other.LastImpact then
 		

--- a/gamedata/lua/lua/shield.lua
+++ b/gamedata/lua/lua/shield.lua
@@ -343,7 +343,7 @@ Shield = Class(moho.shield_methods,Entity) {
     -- Return true to process this collision, false to ignore it.
     OnCollisionCheck = function(self,other)
 	
-		if EntityCategoryContains( categories.SHIELDPIERCING, other ) then
+		if categories.SHIELDPIERCING then
 			return false
 		end
 


### PR DESCRIPTION
credit goes to Balthazar
the current check doesn't work if there is no projectile with the SHIELDPIERCING category in the game
breaks shields when playing LOUD without 4th Dimension since the only projectiles with this category are in the 4th Dimension mod for LOUD