### PR TITLE
Minor refactoring of UI score.lua

### DIFF
--- a/gamedata/lua/lua/ui/game/score.lua
+++ b/gamedata/lua/lua/ui/game/score.lua
@@ -313,7 +313,7 @@ function _OnBeat()
                 if line.armyID == index then
 				
                     if line.OOG then break end
-                    line.score:SetText(scoreData.general.score)
+                    	line.score:SetText(GetScoreText(scoreData))
                     if GetFocusArmy() == index then
                         line.name:SetColor('ffff7f00')
                         line.score:SetColor('ffff7f00')
@@ -374,6 +374,10 @@ function _OnBeat()
 		
 	end
 
+end
+
+function GetScoreText(scoreData)
+	return scoreData.general.score
 end
 
 function SetUnitText(current, cap)


### PR DESCRIPTION
This patch extracts the line that sets the actual score text in the scoreboard into its own function. This allows mods to replace the score text cleanly, without any complicated hooks or having to copy & paste the entire _OnBeat() function.