### PR TITLE
Ignore bat files / Normalize buildTime for Flayer II

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.tif
 *.psd
 *.ps1
+*.bat
 bin/Loud-Dev\.log
 
 bin/ForgedAlliance\.exe

--- a/gamedata/LOUD_Mods/mods/LOUD Unit Additions/units/VEB2302/VEB2302_unit.bp
+++ b/gamedata/LOUD_Mods/mods/LOUD Unit Additions/units/VEB2302/VEB2302_unit.bp
@@ -112,7 +112,7 @@ UnitBlueprint {
 	
         BuildCostEnergy = 145000,
         BuildCostMass = 13000,
-        BuildTime = 2500,
+        BuildTime = 13000,
 		
         RebuildBonusIds = {'veb2302'},
     },


### PR DESCRIPTION
Flayer II buildtime was off, set it to the same as the others.